### PR TITLE
Fix Travis CI job timed out 👷‍♂️

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: true
 addons:
   homebrew:
     brewfile: true
+before_install:
+  - sed -i '' -E '/exiftool|ffmpeg|google-chrome|mounty|virtualbox|whatsapp/d' Brewfile
 script:
-  - sed -i '' -E '/google-chrome|mounty|virtualbox|whatsapp/d' Brewfile
   - brew bundle


### PR DESCRIPTION
Travis CI jobs time out while installing `exiftool`, `ffmpeg`.

> No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
> Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received