### PR TITLE
Use cask to install phantomjs 🎓

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -11,5 +11,5 @@ jobs:
     - uses: actions/checkout@v1
     - name: Brew Bundle
       run: |
-        sed -i '' -E '/djview|exiftool|epic-games|ffmpeg|google-chrome|mounty|node|phantomjs|virtualbox|whatsapp/d' Brewfile
+        sed -i '' -E '/djview|exiftool|epic-games|ffmpeg|google-chrome|mounty|node|virtualbox|whatsapp/d' Brewfile
         brew update && brew bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ addons:
   homebrew:
     brewfile: true
 before_install:
-  - sed -i '' -E '/exiftool|epic-games|ffmpeg|google-chrome|mounty|phantomjs|virtualbox|whatsapp/d' Brewfile
+  - sed -i '' -E '/exiftool|epic-games|ffmpeg|google-chrome|mounty|virtualbox|whatsapp/d' Brewfile
 script:
   - brew update && brew bundle

--- a/Brewfile
+++ b/Brewfile
@@ -41,7 +41,7 @@ cask "visual-studio-code"
 
 # JS
 brew "node"
-brew "phantomjs"
+cask "phantomjs"
 
 # Media
 cask "spotify"


### PR DESCRIPTION
phantomjs now requires `brew cask install`