### PR TITLE
Add Dungeon Crawl Stone Soup to the Games section 🍜

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -26,6 +26,7 @@ brew "redis"
 
 # Games
 brew "c2048"
+cask "dungeon-crawl-stone-soup-tiles"
 cask "epic-games"
 cask "origin"
 cask "steam"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2473081/59508804-d8dc8200-8eb7-11e9-8419-3c3952a538d2.png)

A roguelike adventure through dungeons filled with dangerous monsters in a quest to find the mystifyingly fabulous Orb of Zot.

`cask "dungeon-crawl-stone-soup-tiles"`