### PR TITLE
Add Cataclysm: Dark Days Ahead to the Games section 🧟‍♂️

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -26,6 +26,7 @@ brew "redis"
 
 # Games
 brew "c2048"
+brew "cataclysm"
 brew "curseofwar"
 brew "nudoku"
 brew "tty-solitaire"


### PR DESCRIPTION
# Cataclysm: Dark Days Ahead

Cataclysm: Dark Days Ahead is a turn-based survival game set in a post-apocalyptic world. Struggle to survive in a harsh, persistent, procedurally generated world. Scavenge the remnants of a dead civilization for food, equipment, or, if you are lucky, a vehicle with a full tank of gas to get you the hell out of Dodge. Fight to defeat or escape from a wide variety of powerful monstrosities, from zombies to giant insects to killer robots and things far stranger and deadlier, and against the others like yourself, that want what you have…

`brew "cataclysm"`

Website: https://cataclysmdda.org/
GitHub: https://github.com/CleverRaven/Cataclysm-DDA/